### PR TITLE
Emulator fixes

### DIFF
--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -160,7 +160,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandEtSum>0){ //check if not empty
     for (int iEtSum = 0; iEtSum < NCandEtSum; iEtSum++) {    
       if ((candEtSumVec->at(useBx, iEtSum))->getType() == l1t::EtSum::EtSumType::kMissingEt) { 
-	EtSumInput[0] = ((candEtSumVec->at(useBx, iEtSum))->hwPt())/2; //have to do hwPt/2 in order to match original et inputs
+	EtSumInput[0] = float((candEtSumVec->at(useBx, iEtSum))->hwPt())/2; //have to do hwPt/2 in order to match original et inputs
 	// EtSumInput[1] = (candEtSumVec->at(useBx, iEtSum))->hwEta(); //this one is zero, so leave it zero
 	EtSumInput[2] = (candEtSumVec->at(useBx, iEtSum))->hwPhi();
       }}}
@@ -169,7 +169,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandEG>0){//check if not empty
     for (int iEG = 0; iEG < NCandEG; iEG++) {  
       if (iEG<NEgammas) { //stop if fill the Nobjects we need
-	EgammaInput[0+(3*iEG)] = ((candEGVec->at(useBx, iEG))->hwPt())/2;   //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
+	EgammaInput[0+(3*iEG)] = float((candEGVec->at(useBx, iEG))->hwPt())/2;   //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
 	EgammaInput[1+(3*iEG)] = (candEGVec->at(useBx, iEG))->hwEta();  //index 1,4,7,10
 	EgammaInput[2+(3*iEG)] = (candEGVec->at(useBx, iEG))->hwPhi();  //index 2,5,8,11
 	}}}
@@ -178,7 +178,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandMu>0){//check if not empty
     for (int iMu = 0; iMu < NCandMu; iMu++) {  
       if (iMu<NMuons) { //stop if fill the Nobjects we need
-	MuInput[0+(3*iMu)] = ((candMuVec->at(useBx, iMu))->hwPt())/2;   //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
+	MuInput[0+(3*iMu)] = float((candMuVec->at(useBx, iMu))->hwPt())/2;   //index 0,3,6,9 //have to do hwPt/2 in order to match original et inputs
 	MuInput[1+(3*iMu)] = (candMuVec->at(useBx, iMu))->hwEta();  //index 1,4,7,10
 	MuInput[2+(3*iMu)] = (candMuVec->at(useBx, iMu))->hwPhi();  //index 2,5,8,11
 	}}}
@@ -187,7 +187,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   if (NCandJet>0){//check if not empty
     for (int iJet = 0; iJet < NCandJet; iJet++) {  
       if (iJet<NJets) { //stop if fill the Nobjects we need
-	JetInput[0+(3*iJet)] = ((candJetVec->at(useBx, iJet))->hwPt())/2;   //index 0,3,6,9...27 //have to do hwPt/2 in order to match original et inputs
+	JetInput[0+(3*iJet)] = float((candJetVec->at(useBx, iJet))->hwPt())/2;   //index 0,3,6,9...27 //have to do hwPt/2 in order to match original et inputs
 	JetInput[1+(3*iJet)] = (candJetVec->at(useBx, iJet))->hwEta();  //index 1,4,7,10...28
 	JetInput[2+(3*iJet)] = (candJetVec->at(useBx, iJet))->hwPhi();  //index 2,5,8,11...29
 	}}}


### PR DESCRIPTION
- [x] Make types match standalone emulator in external repo https://github.com/cms-hls4ml/AXOL1TL/pull/6 
- [x] Up to 0.5 difference remains on the ET or pT. I think this is because in CMSSW now we have an integer division. So probably doing like float((candEGVec->at(useBx, iEG))->hwPt())/2 would fix it
- [ ] The agreement on egs is okay for ET (apart from above issue) but quite bad for eta, phi
- [ ] The agreement on jets is bad for ET, but ~okay for eta,phi. Maybe there’s a corrected and uncorrected ET that we use inconsistently?
- [x] MET probably differs only because of the above. On phi it matches
- [x] The agreement on muons is quite good
- [x] The agreement on egs is okay for ET (apart from above issue) but quite bad for eta, phi

![inputs_residuals_zoom](https://github.com/quinnanm/cmssw/assets/4932543/1e0d01bd-8142-4cc9-9a00-add5d62c285e)

@thesps @artlbv @quinnanm 